### PR TITLE
Dokuwiki does not allow mutated vowels in file names

### DIFF
--- a/src/mediawiki2dokuwiki.php
+++ b/src/mediawiki2dokuwiki.php
@@ -163,7 +163,7 @@ function processImage(array $record, array $lang) {
 	
     # File path
 	$src_file_path = realpath(dirname(MWIKI_ROOT) . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . $dir1 .DIRECTORY_SEPARATOR .$dir2. DIRECTORY_SEPARATOR .$record['page_title']);
-    $dst_file_path = dirname(__FILE__). DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'mediawiki' . DIRECTORY_SEPARATOR . cleanID($record['page_title']));
+    $dst_file_path = dirname(__FILE__). DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'mediawiki' . DIRECTORY_SEPARATOR . cleanID($record['page_title']);
 
     if (!is_dir(dirname($dst_file_path))) {
         mkdir(dirname($dst_file_path));


### PR DESCRIPTION
When you use german mutated vowels or special characters (like () etc.) in your uploaded filenames, the converter does not convert or delete them so Dokuwiki can't use the files, because special characters and mutated vowels are not allowed in Dokuwikis media manager.

It would be great if the converter could translate mutated vowels and special characters into a format that is accepted by Dokuwiki.
