### PR TITLE
Some fixes to work with DokuWiki 0.0.20091225c and MediaWiki 1.15.5

### DIFF
--- a/src/MediaWiki2DokuWiki/MediaWiki/Converter.php
+++ b/src/MediaWiki2DokuWiki/MediaWiki/Converter.php
@@ -77,11 +77,13 @@ class MediaWiki2DokuWiki_MediaWiki_Converter
      */
     public function convert(PDO $db)
     {
+        $textTable = $db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'pgsql' ? "pagecontent" : "text"; 
+        
         $sql = "SELECT      p.page_title, p.page_namespace, t.old_text
                 FROM        {$this->dbPrefix}page p
                 INNER JOIN  {$this->dbPrefix}revision r ON
                             p.page_latest = r.rev_id
-                INNER JOIN  {$this->dbPrefix}text t ON
+                INNER JOIN  {$this->dbPrefix}{$textTable} t ON
                             r.rev_text_id = t.old_id
                 ORDER BY    p.page_title";
 

--- a/src/MediaWiki2DokuWiki/MediaWiki/Namespace/Page.php
+++ b/src/MediaWiki2DokuWiki/MediaWiki/Namespace/Page.php
@@ -1,4 +1,5 @@
 <?php
+require_once(DOKU_INC . "inc/common.php");
 /**
  * MediaWiki2DokuWiki importer.
  * Copyright (C) 2011-2013  Andrei Nicholson

--- a/src/MediaWiki2DokuWiki/MediaWiki/Settings.php
+++ b/src/MediaWiki2DokuWiki/MediaWiki/Settings.php
@@ -174,13 +174,18 @@ class MediaWiki2DokuWiki_MediaWiki_Settings
      */
     private function generateDsn()
     {
+        // MediaWiki allows 'postgres' as db type.
+        if ($this->settings['wgDBtype'] == 'postgres') {
+            $this->settings['wgDBtype'] = 'pgsql';
+        }
+        
         $dsn = array(
             $this->settings['wgDBtype'] . ':dbname=' . $this->settings['wgDBname']
         );
-
+        
         $mysqlSocket = ini_get('mysql.default_socket');
 
-        if (!empty($mysqlSocket)) {
+        if ($this->settings['wgDBtype'] == 'mysql' && !empty($mysqlSocket)) {
             $dsn[] = 'unix_socket=' . $mysqlSocket;
         } else {
             $dsn[] = 'host=' . $this->settings['wgDBserver'];


### PR DESCRIPTION
Fixes
- Postgres configuration should use pgsql driver
- Postgres uses different table names
- For some reason DokuWiki's inc/common.php was not included, causing `saveWikiText` to be undefined.